### PR TITLE
Symlink JDK bin/* into /usr/local/bin so java is on PATH in non-login shells

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -68,6 +68,23 @@
         src: '{{ temurin_install_subdir }}'
         dest: '{{ temurin_install_link }}'
         state: link
+    - name: Find executables in {{ temurin_install_subdir }}/bin
+      become: true
+      become_user: root
+      ansible.builtin.find:
+        paths: '{{ temurin_install_subdir }}/bin'
+        file_type: file
+      register: temurin_bin_files
+    - name: Linking executables from {{ temurin_install_link }}/bin into {{ temurin_bin_dir }}
+      become: true
+      become_user: root
+      loop: '{{ temurin_bin_files.files }}'
+      loop_control:
+        label: '{{ item.path | basename }}'
+      ansible.builtin.file:
+        src: '{{ temurin_install_link }}/bin/{{ item.path | basename }}'
+        dest: '{{ temurin_bin_dir }}/{{ item.path | basename }}'
+        state: link
     - name: Adding openjdk to default path and easing systemd integration
       become: true
       become_user: root

--- a/test-jdk-exe.yml
+++ b/test-jdk-exe.yml
@@ -1,6 +1,6 @@
 ---
 - name: Executing 'javac -version'
-  ansible.builtin.command: /usr/local/openjdk-jdk/bin/javac -version
+  ansible.builtin.command: javac -version
   changed_when: false
   register: temurin_jdk_test_output
 - name: Output (stdout) from 'javac -version'

--- a/test-jre-exe.yml
+++ b/test-jre-exe.yml
@@ -1,6 +1,6 @@
 ---
 - name: Executing 'java -version'
-  ansible.builtin.command: /usr/local/openjdk-jre/bin/java -version
+  ansible.builtin.command: java -version
   changed_when: false
   register: temurin_jre_test_output
 - name: Output (stderr) from 'java -version'

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -65,6 +65,7 @@ temurin_install_subdir: |-
   {%- if temurin_app == "jre" %}-jre{% endif -%}
 
 temurin_install_link: '{{ temurin_parent_install_dir }}/openjdk-{{ temurin_app }}'
+temurin_bin_dir: '{{ temurin_parent_install_dir }}/bin'
 temurin_keytool_exe: '{{ temurin_install_subdir }}/bin/keytool'
 
 temurin_keystore: |-


### PR DESCRIPTION
## Summary
- Adds a `Find` + `file: state=link` pair that walks `{{ temurin_install_subdir }}/bin` and drops a symlink into `{{ temurin_bin_dir }}` (default `/usr/local/bin`) for every executable.
- Adds `temurin_bin_dir` to `vars/main.yml`, composed from `temurin_parent_install_dir`.
- Keeps `/etc/profile.d/openjdk.sh` (still useful for `JAVA_HOME` in interactive shells) and the `openjdk.env` file beside the JDK.
- Test playbooks now invoke `java -version` / `javac -version` by bare name so they exercise the new `/usr/local/bin` symlinks.

## Why
`/etc/profile.d/openjdk.sh` only sources for interactive login shells. Cron jobs, systemd units, `sudo` invocations, most CI shells, and dependent roles like `andrewrothstein.flyway` therefore can't find `java` without setting `JAVA_HOME` themselves or wrapping entry points in `bash -l -c`. Symlinking the binaries into `/usr/local/bin` is the FHS-blessed way to make them discoverable in every shell context.

## Test plan
- [ ] `which java` resolves to `/usr/local/bin/java` from a fresh non-login shell.
- [ ] `java -version` works under `sudo -i` and under a `crontab` entry.
- [ ] Re-run on an upgraded host: existing symlinks under `/usr/local/bin` get repointed at the new install_link, no orphans.
- [ ] CI matrix passes across all distros.

🤖 Generated with [Claude Code](https://claude.com/claude-code)