### PR TITLE
8u492-b09 26.0.1+8

### DIFF
--- a/defaults/main/temurin-checksums.yml
+++ b/defaults/main/temurin-checksums.yml
@@ -721,6 +721,41 @@ temurin_checksums:
       mac_x64: sha256:df3c40357842b742fc5f838302c017835b9baeb48dd6213dde9b3774075dab90
       # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u482-b08/OpenJDK8U-jre_x64_windows_hotspot_8u482b08.zip.sha256.txt
       windows_x64: sha256:61c4fe5c2d3c06cf6fa79de8e62da52444c95be1616b8dc8ad1e6d8db72f37bf
+  '8u492b09':
+    jdk:
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_ppc64_aix_hotspot_8u492b09.tar.gz.sha256.txt
+      aix_ppc64: sha256:60177a0140961507d8d103d9a17437919657e3ab40eba4cb11439ba6bf26bc2a
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_alpine-linux_hotspot_8u492b09.tar.gz.sha256.txt
+      alpine-linux_x64: sha256:5db39d393a0c3c5c8bb0c639e6f74edc474a13c84d3caf33dc9ba3bba0097a49
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_x64: sha256:da257f161d7f8c6ca5b0e5d9e4090f65ac28c5e398072e68b8ae87988b1d1a2e
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_aarch64_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_aarch64: sha256:3c2253b986909c20f79d6de7a0cb957f89c243df57615897836046e24d2e5257
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_arm_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_arm: sha256:ac93b4b75d6c0592c83030dbbeeaed46f5fbfccb276cf26c86aab3e49bba090e
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_ppc64le_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_ppc64le: sha256:867e477e0a54159c7b774c55cfb046767120b1de43f705fa775ece74ea39e341
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_mac_hotspot_8u492b09.tar.gz.sha256.txt
+      mac_x64: sha256:dd2cc870118fe9fba136e48b2988cfa63d3bda46cc6f1646677cae27a1a02e99
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jdk_x64_windows_hotspot_8u492b09.zip.sha256.txt
+      windows_x64: sha256:1e33881ea6bfc1c532e3eaad1c1de7777169c0c1333e2b880621e0e0a16073b2
+    jre:
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_ppc64_aix_hotspot_8u492b09.tar.gz.sha256.txt
+      aix_ppc64: sha256:a34656057ae9a00b80d9876c8d0c704a0e56ddb1cd86b75bf7da989edcbf9566
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_alpine-linux_hotspot_8u492b09.tar.gz.sha256.txt
+      alpine-linux_x64: sha256:82b74dc9042ce6735624a1ca9585e6a43c44f0f6093a7f2088b0a622f304d62c
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_x64: sha256:8eef3d4a837bb7a9e45d30a7579d84d5b76a4321f4376573311e6bf89e48f9b0
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_aarch64_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_aarch64: sha256:d5e50cb002600007dbdfac523605d26196607fa5212db0942ef05cdce9fe2892
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_arm_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_arm: sha256:5f0693c6c8ca0eb8df969bb1053b1926b1e7c57a3f90c6f9e8d493395e76a329
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_ppc64le_linux_hotspot_8u492b09.tar.gz.sha256.txt
+      linux_ppc64le: sha256:4f724a0fce1117521a3a3e55ebb0281d56f6c9a066092bc3186ee40d8cd955a2
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_mac_hotspot_8u492b09.tar.gz.sha256.txt
+      mac_x64: sha256:e4acfc82781f0a4ec1fb9785afee41dcb4bb444655d445a2b31edbacbe6bf040
+      # https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u492-b09/OpenJDK8U-jre_x64_windows_hotspot_8u492b09.zip.sha256.txt
+      windows_x64: sha256:bb25b002556afc7ef158cd95ec6270dddb3eecba69acdd7abb9d28b2e9ff0f5e
   '11.0.13_8':
     jdk:
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.13%2B8/OpenJDK11U-jdk_ppc64_aix_hotspot_11.0.13_8.tar.gz.sha256.txt
@@ -1594,25 +1629,45 @@ temurin_checksums:
     jdk:
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_ppc64_aix_hotspot_11.0.31_11.tar.gz.sha256.txt
       aix_ppc64: sha256:31881c9178e39334f10e8d175c95f466806c752eb46ffed91a75f7c4a51b6c2c
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_x64_alpine-linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      alpine-linux_x64: sha256:ed06a4b8381786a6e8091c10539856675497d2b821cd2d0200cc5b65f453b982
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_s390x_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      linux_s390x: sha256:4d3709cdc03de1a00f14f530c2ebad1883d9bcc8a556fc419f083bec87b4687a
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_x64_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
       linux_x64: sha256:1e9de64586b519c0a981319489257cabedd9457599f3823424a87c3158fbe939
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_aarch64_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      linux_aarch64: sha256:257f4d39e060658fc2eb89a803ca43b3f337e64e253f2d94ebae1d85c9ef5f69
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_arm_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      linux_arm: sha256:3e0ff500a650a552adb2478895ba5de2b133da9b4b816fa76095969b4eec61ce
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_ppc64le_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
       linux_ppc64le: sha256:e473d10c3c44f67301fd90abd9e4b7ae312eae8a2399b333fcf4179daf35a743
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.31_11.tar.gz.sha256.txt
       mac_aarch64: sha256:e3377bbe07f4396ba03adcfc5f3d71d151d6a7b858abdf1d0dd20ac4d8d709b0
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_x64_mac_hotspot_11.0.31_11.tar.gz.sha256.txt
       mac_x64: sha256:e541fa6c6100b6dd6ae0c92c96ae8d97ed4d94ddefb0cd2770dae4772bfc9d9e
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jdk_x64_windows_hotspot_11.0.31_11.zip.sha256.txt
+      windows_x64: sha256:5695bd8fed700acb74e0c13945fc6d7564441a31d345c100b82ee1aac553a6b7
     jre:
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_ppc64_aix_hotspot_11.0.31_11.tar.gz.sha256.txt
       aix_ppc64: sha256:4a0e6e3ccb297d5962ea7ad76f7017c15f7f4e566bc82755b424c23f8876b44f
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_alpine-linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      alpine-linux_x64: sha256:4a1ba44d0b28523ff5b73a5015f3bcc6b9d36f3ac313ffb87762946af7f642ce
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_s390x_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      linux_s390x: sha256:4c311b19aa3922951be288076f0f41a831ab7af32284da9b3e21cdaa251a078a
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
       linux_x64: sha256:a6af3d61851f57eb79ef0189837522329717458bf230ee284da2d26634f1ea3a
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_aarch64_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      linux_aarch64: sha256:eabe05fb80626ad24db17cf1df137855e77fbacbc83c11aaf243cedd224467de
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_arm_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
+      linux_arm: sha256:5d3e988cdc8291779068c957c01d339f26178ff65d13af4671107b169e80a69f
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_ppc64le_linux_hotspot_11.0.31_11.tar.gz.sha256.txt
       linux_ppc64le: sha256:11e58bf1eeae10f0dc1a98cc43bf97af270a0b516f6ff9fb3189024c5e22550a
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_aarch64_mac_hotspot_11.0.31_11.tar.gz.sha256.txt
       mac_aarch64: sha256:b2bddcb43b2f8343f6517570acacd2b6cd0d5035ac797751f55395a26232c7e4
       # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_mac_hotspot_11.0.31_11.tar.gz.sha256.txt
       mac_x64: sha256:a98534ac5a87c22b5c9f47296aac4f5671c4015ce8af9b575b2fdf1408cabd3a
+      # https://github.com/adoptium/temurin11-binaries/releases/download/jdk-11.0.31%2B11/OpenJDK11U-jre_x64_windows_hotspot_11.0.31_11.zip.sha256.txt
+      windows_x64: sha256:0af0760609eca44502f05e6ab4701eecbf85290f31278dabc41dceddab7237ab
   '16.0.2_7':
     jdk:
       # https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_alpine-linux_hotspot_16.0.2_7.tar.gz.sha256.txt
@@ -2487,27 +2542,47 @@ temurin_checksums:
       windows_x64: sha256:95c9ebe3ee16baab7239531757513d9a03799ca06483ef2f3b530e81e93e7b5b
   '17.0.19_10':
     jdk:
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_ppc64_aix_hotspot_17.0.19_10.tar.gz.sha256.txt
+      aix_ppc64: sha256:912c317c7ca87602fd878ed388d2806af5a49b3e9b473d2196897f28fd6449ca
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_alpine-linux_hotspot_17.0.19_10.tar.gz.sha256.txt
       alpine-linux_x64: sha256:960b4090b75a887bb21a915a294bee3a97cd11876967c95e5bd29d9ec4812e17
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
+      linux_s390x: sha256:00363a5ceda57aa0dee89d20b3f6b2966e3c1f3fb6dcf57e66d2264573d3c63e
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
       linux_x64: sha256:d8afc263758141a66e0e3aafc321e783f7016696f4eaea067d340a269037d331
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
+      linux_aarch64: sha256:83a52172678ec8975164648654869cb2e71d7c748b47aca94b29bbfa10c18e81
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_arm_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
+      linux_arm: sha256:2de430307390123858ea70b3ba399155b88bb05d65e5d3633b3a4d7b19acddb1
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
       linux_ppc64le: sha256:c9d8dc52960ff00aa8c321e211cc5284a2151cffdedeac998f5297066cbad245
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_aarch64_mac_hotspot_17.0.19_10.tar.gz.sha256.txt
       mac_aarch64: sha256:8fa1eff40bb637a33613b2ccb8b12c70dc3661cc22cf8e784943715769a05336
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_mac_hotspot_17.0.19_10.tar.gz.sha256.txt
       mac_x64: sha256:03632d1fbf139ab3719a9f4b47dc206251449b87557143c822336dbf8c06560f
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip.sha256.txt
+      windows_x64: sha256:b5b235c48adf6a081874b812c630b9f4b5f637b7a5ed18b9174d08a41ec4c235
     jre:
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_ppc64_aix_hotspot_17.0.19_10.tar.gz.sha256.txt
+      aix_ppc64: sha256:b82afd153eb68b715a1c993499fbe8ede7ba70a0a9f4826e0ce91483f8357e44
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_x64_alpine-linux_hotspot_17.0.19_10.tar.gz.sha256.txt
       alpine-linux_x64: sha256:22d4d5579902d134dede626d0fdfb95891abc7578e13dea9cb23775498c4cf51
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_s390x_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
+      linux_s390x: sha256:674547d46dad6909fdcdafe5a691c131b048a8d226ccd7d0a4e96f2b208d772a
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_x64_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
       linux_x64: sha256:adb5a2364baa51de1ef91bb9911f5a61d24b045fe1d6647cb8050272a3a8ee75
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_aarch64_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
+      linux_aarch64: sha256:aae834297a87736869745be7c1fca3207ea9167c5824f41c88b0ebb2e3ccb9b1
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_arm_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
+      linux_arm: sha256:018d1f5c11b2f1a2175c282a0fe8a17d9166da84b70ec1c60c1fa628a261d1eb
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_ppc64le_linux_hotspot_17.0.19_10.tar.gz.sha256.txt
       linux_ppc64le: sha256:1b028a08d96054ef29a3b6c424537d9644e0ec5fb5742a64d967dd56d5571b6b
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_aarch64_mac_hotspot_17.0.19_10.tar.gz.sha256.txt
       mac_aarch64: sha256:cef790b404cf168fd1a8a7abc5054fbb442c7d4bfe390cceccfe3f64b9b776a9
       # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_x64_mac_hotspot_17.0.19_10.tar.gz.sha256.txt
       mac_x64: sha256:91bbd07b9c65d9ecbe1fa0081b3c1ad549ed34ed21085a72fdb76598a740b54c
+      # https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jre_x64_windows_hotspot_17.0.19_10.zip.sha256.txt
+      windows_x64: sha256:79a598e1fbb4e16582d92c4ee22280a3c4d72fd52606e1e46b1223c0fe53b0da
   '18.0.1_10':
     jdk:
       # https://github.com/adoptium/temurin18-binaries/releases/download/jdk-18.0.1%2B10/OpenJDK18U-jdk_x64_alpine-linux_hotspot_18.0.1_10.tar.gz.sha256.txt
@@ -3238,8 +3313,14 @@ temurin_checksums:
       alpine-linux_x64: sha256:38bfdcef1e4b45de2ec222047ac79c76bea75d4d7406a310e26cfa236763f05f
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_alpine-linux_hotspot_21.0.11_10.tar.gz.sha256.txt
       alpine-linux_aarch64: sha256:c8d63598d1dc0a656033515ed258bd6db37506a05407d9f65cd23b95c21027b5
+      # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_s390x_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
+      linux_s390x: sha256:14dbe3cb226e64b945a36bea32686e8deec746504fe3ccee8de585c54af41ffd
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
       linux_x64: sha256:4b2220e232a97997b436ca6ab15cbf70171ecff52958a46159dfa5a8c44ca4de
+      # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
+      linux_aarch64: sha256:8d498ec88e1c1989fab95c6784240ab92d011e29c54d20a3f9c324b13476f9ad
+      # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_ppc64le_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
+      linux_ppc64le: sha256:3d043ae96d2343962bf2307d8c55f19849fbfa4c6be9fe164a77d79263f0d989
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_aarch64_mac_hotspot_21.0.11_10.tar.gz.sha256.txt
       mac_aarch64: sha256:6ebcf221c9b41507b14c098e93c6ead6440b8d9bd154f8ec666c4c73abbdb201
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_mac_hotspot_21.0.11_10.tar.gz.sha256.txt
@@ -3253,8 +3334,14 @@ temurin_checksums:
       alpine-linux_x64: sha256:b75c9f0dd052adfd213f0c2c1cc0c8a6d4539a8de9f7947d2b8fc45d18289975
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_aarch64_alpine-linux_hotspot_21.0.11_10.tar.gz.sha256.txt
       alpine-linux_aarch64: sha256:33399db5fb4f542df36a706d6642a3ba1fab3d247da707273a11ef29e39f0705
+      # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_s390x_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
+      linux_s390x: sha256:45736e9e14d52619133900a077b4f72d1ebee0fd0bb053da0bca9dce9fc4d916
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_x64_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
       linux_x64: sha256:e5038aae3ca9ff670bc696496b0728dbd23d280026bad30291cb919221ecfdcb
+      # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_aarch64_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
+      linux_aarch64: sha256:fa23d9d9945053e67bcc7638410eabf1e17a7672c7c95a24f70cd08b8407d36e
+      # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_ppc64le_linux_hotspot_21.0.11_10.tar.gz.sha256.txt
+      linux_ppc64le: sha256:fefb53c4bd687e7a91a9a9809ec80e0862e829cd20513839ad1a9988ddc89482
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_aarch64_mac_hotspot_21.0.11_10.tar.gz.sha256.txt
       mac_aarch64: sha256:4b7a8cd23102c251c8b8be42a9a5f1263fb337cf1037f6f64b25f3070efe4b76
       # https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jre_x64_mac_hotspot_21.0.11_10.tar.gz.sha256.txt
@@ -3513,6 +3600,8 @@ temurin_checksums:
       windows_x64: sha256:1919e7e1603bc5937187139db2d65824f8d95ef42d0423ae9f9f1d9eb97842f6
   '25.0.3_9':
     jdk:
+      # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_ppc64_aix_hotspot_25.0.3_9.tar.gz.sha256.txt
+      aix_ppc64: sha256:af071adb9b7cb17ffab041b4525a4e5c3d015e20272ee90d1c0799f942831c29
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_alpine-linux_hotspot_25.0.3_9.tar.gz.sha256.txt
       alpine-linux_x64: sha256:51c2415b370aac7c3796b0c4663c8fcf91bc22d76f03df95b25fa5667cb5fdd8
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_alpine-linux_hotspot_25.0.3_9.tar.gz.sha256.txt
@@ -3521,13 +3610,19 @@ temurin_checksums:
       linux_s390x: sha256:24b497d10acb6ee706ca30e1c8a929785c250cad54c5c12f1f8f93c3c06a53f7
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_linux_hotspot_25.0.3_9.tar.gz.sha256.txt
       linux_x64: sha256:69264a7a211bf5029830d07bc3370f879769d62ebc5b5488e90c9343a2da0e1f
+      # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_linux_hotspot_25.0.3_9.tar.gz.sha256.txt
+      linux_aarch64: sha256:3e4287cb98870ba824ed698854bdc27cff984254caf66dd12cc291e7bfdde26b
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_ppc64le_linux_hotspot_25.0.3_9.tar.gz.sha256.txt
       linux_ppc64le: sha256:72b0fbb201716ca465ab704ec0fb12971abab3fdde5ae8d03b125a273522cf05
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_aarch64_mac_hotspot_25.0.3_9.tar.gz.sha256.txt
       mac_aarch64: sha256:7baab4d69a15554e119b86ff78d40e3fdc28819b5b322955c913cebfe3f6a37c
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_mac_hotspot_25.0.3_9.tar.gz.sha256.txt
       mac_x64: sha256:4c539a18b4d656960ff6766727e9ca546fc17f7a29714dba9e7b47bdcb37c447
+      # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip.sha256.txt
+      windows_x64: sha256:709312cd0420296d9b9de917fe6e28a5b979e875ee5ab91783fb79bcd5857235
     jre:
+      # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_ppc64_aix_hotspot_25.0.3_9.tar.gz.sha256.txt
+      aix_ppc64: sha256:357319388e62d985b38b2a32b635618dd2b355bff5f34d59e0e976916daf5314
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_alpine-linux_hotspot_25.0.3_9.tar.gz.sha256.txt
       alpine-linux_x64: sha256:ad202c8f8b216800ed0d6581130f92e5680b685ba394ba38e62e7605c3fd9494
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_alpine-linux_hotspot_25.0.3_9.tar.gz.sha256.txt
@@ -3536,12 +3631,16 @@ temurin_checksums:
       linux_s390x: sha256:ee513969bef35f10afb7d06840d9a421138a3d30c062cde3dda8fe780dc451a2
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_linux_hotspot_25.0.3_9.tar.gz.sha256.txt
       linux_x64: sha256:487ad434d8b121ae3902d5ad9cb830cd8e1f75fefad6e2ba80f89d60e3db95d7
+      # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_linux_hotspot_25.0.3_9.tar.gz.sha256.txt
+      linux_aarch64: sha256:d12d5b19ff7f6c4a99fd4f9eecede2c96e64df7d1f41cc84f2e9c9b38408600b
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_ppc64le_linux_hotspot_25.0.3_9.tar.gz.sha256.txt
       linux_ppc64le: sha256:82daf66b73505d3974d831bd244acbb1123a340b7752ced449dcdca69ff3a780
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_aarch64_mac_hotspot_25.0.3_9.tar.gz.sha256.txt
       mac_aarch64: sha256:287cc80077dc2ffd0e5733ba238f92206a84c26bef33e6881a23c213e4c35af4
       # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_mac_hotspot_25.0.3_9.tar.gz.sha256.txt
       mac_x64: sha256:594bf4e7d15b622157a54915de7e458c208e3363d61a5e488d8abfbda9aff3e5
+      # https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jre_x64_windows_hotspot_25.0.3_9.zip.sha256.txt
+      windows_x64: sha256:a183e7280220ad5f6fe94ecbf025a5f10fc5797a0b18c600ed8f813c8158c530
   '26_35':
     jdk:
       # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jdk_ppc64_aix_hotspot_26_35.tar.gz.sha256.txt
@@ -3585,3 +3684,46 @@ temurin_checksums:
       mac_x64: sha256:67d8049ff31ca1ffe3329162c0ed895cc074e37a19dd2c43ac3121ec3d889084
       # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26%2B35/OpenJDK26U-jre_x64_windows_hotspot_26_35.zip.sha256.txt
       windows_x64: sha256:5b776c83068703c4f6b52545673161981a74262d9751aba7eaa87b38a19beb8d
+  '26.0.1_8':
+    jdk:
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_ppc64_aix_hotspot_26.0.1_8.tar.gz.sha256.txt
+      aix_ppc64: sha256:67c3cb5d30166dff46485c21ca75fe748f52328250df2842716c547516a8ed28
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_alpine-linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      alpine-linux_x64: sha256:0c97fe7e503fb6daf36a5e86e8d083b97cc2354cda4d11288e6c3b8ec0818afc
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_aarch64_alpine-linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      alpine-linux_aarch64: sha256:7e32b89349385f10d7805197c7696b46556717d041e681017b12590bae6692ca
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_s390x_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_s390x: sha256:942de7ded1427592a2a4b6dbea4083b2d0891de2626c7863e970de3e2819a93f
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_x64: sha256:8e512f13e575a43655fc92319436c94890c137b9035cc6bd6f9cf24239704d3a
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_aarch64_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_aarch64: sha256:613f9b2861dea937b24d5eca745ef8567733b377d0bb612195acaad0e3f61360
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_ppc64le_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_ppc64le: sha256:60e016faf4177840430035d948f83f2887d556fe512b78c1d43b320322fe6685
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_aarch64_mac_hotspot_26.0.1_8.tar.gz.sha256.txt
+      mac_aarch64: sha256:10c436258e24693ce8baf13dbffce98b77275797455e8b72510967547f13234a
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_mac_hotspot_26.0.1_8.tar.gz.sha256.txt
+      mac_x64: sha256:032df492c8749864ee8b135e3d0ea5a17ef5c847309d5fdf8f1dd55e246b8319
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jdk_x64_windows_hotspot_26.0.1_8.zip.sha256.txt
+      windows_x64: sha256:81b35819085dd73a204c3219464c5f154cb111a526ec63dad793c0eefd469b3d
+    jre:
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_ppc64_aix_hotspot_26.0.1_8.tar.gz.sha256.txt
+      aix_ppc64: sha256:d016f9beca7f04438b99b4a63447ff198dbe372af6c6c0866e7575d95ecfbe08
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_alpine-linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      alpine-linux_x64: sha256:d218b359f735122cadeb9cbb226c4ddff8746c46a8d5b833809aedff85bd48a6
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_aarch64_alpine-linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      alpine-linux_aarch64: sha256:3106f091aad558977d890b0f6639beacd2815ea051a75a23733b3b16fee6ca55
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_s390x_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_s390x: sha256:3c68d7df7d64a7738a6bd97b12fb2167774666d87bf9a309094bb2180073eb38
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_x64: sha256:2e90cf68d31b28553fb2c8202d5a4c3a5e99a60285e125dc28c94ba5fb2ac1ef
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_aarch64_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_aarch64: sha256:bf5f733066599065de5e720edda550b39d85876f5bf23a94fee2cb6a8379cb36
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_ppc64le_linux_hotspot_26.0.1_8.tar.gz.sha256.txt
+      linux_ppc64le: sha256:d8f66903603c3661c0d8c03de41b76459260ed2e295ba874bb7b3f37a012c026
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_aarch64_mac_hotspot_26.0.1_8.tar.gz.sha256.txt
+      mac_aarch64: sha256:ae27bc97ad353fe910df1b50ca989146561260c00762d65a797682068275dec9
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_mac_hotspot_26.0.1_8.tar.gz.sha256.txt
+      mac_x64: sha256:c717204061632d41439e5197a36f26cbfe7695fe1161bcf12d613394cafdae3a
+      # https://github.com/adoptium/temurin26-binaries/releases/download/jdk-26.0.1%2B8/OpenJDK26U-jre_x64_windows_hotspot_26.0.1_8.zip.sha256.txt
+      windows_x64: sha256:bab6b82ad8600dc177f45b3225d5810779fe9d90179561d877a731294e173404

--- a/dl-checksums.go
+++ b/dl-checksums.go
@@ -234,6 +234,7 @@ func main() {
 		{Major: 8, Minor: 462, Patch: "0", BVer: "08"},
 		{Major: 8, Minor: 472, Patch: "0", BVer: "08"},
 		{Major: 8, Minor: 482, Patch: "0", BVer: "08"},
+		{Major: 8, Minor: 492, Patch: "0", BVer: "09"},
 		{Major: 11, Minor: 0, Patch: "13", BVer: "8"},
 		{Major: 11, Minor: 0, Patch: "14.1", BVer: "1"},
 		{Major: 11, Minor: 0, Patch: "15", BVer: "10"},
@@ -302,6 +303,7 @@ func main() {
 		{Major: 25, Minor: 0, Patch: "2", BVer: "10"},
 		{Major: 25, Minor: 0, Patch: "3", BVer: "9"},
 		{Major: 26, Minor: 0, Patch: "", BVer: "35"},
+		{Major: 26, Minor: 0, Patch: "1", BVer: "8"},
 	}
 	dlall(1, &params, versions, platforms)
 }

--- a/test.yml
+++ b/test.yml
@@ -4,8 +4,8 @@
   vars:
     temurin_ver:
       major: 8
-      minor: 482
-      b: '08'
+      minor: 492
+      b: '09'
 - name: Testing andrewrothstein.temurin (11)
   ansible.builtin.import_playbook: test-ver.yml
   vars:
@@ -92,6 +92,7 @@
     temurin_ver:
       major: 26
       minor: 0
-      b: "35"
+      patch: "1"
+      b: "8"
 - name: Testing andrewrothstein.temurin (latest)
   ansible.builtin.import_playbook: test-ver.yml


### PR DESCRIPTION
## Summary
- Add Temurin `8u492-b09` and `26.0.1+8` to `dl-checksums.go` and regenerate `defaults/main/temurin-checksums.yml`
- Bump `test.yml` Java 8 and Java 26 entries to the new latest patches

## Test plan
- [ ] CI build passes
- [ ] `test.yml` exercises the new 8u492-b09 and 26.0.1+8 versions across supported platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)